### PR TITLE
feat: support case where day of week value ranges from 0 to 6

### DIFF
--- a/__tests__/OneCron.test.tsx
+++ b/__tests__/OneCron.test.tsx
@@ -1,7 +1,7 @@
 import * as Enzyme from "enzyme";
 import * as Adapter from "enzyme-adapter-react-16";
 import * as React from "react";
-import OneCron from "../src";
+import OneCron, { cronValidate } from "../src";
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -51,4 +51,15 @@ it("dayOfWeekOneBased prop is false", () => {
   expect(cronOne.find(".errorCronExp").length).toBe(0);
   // 应该选中周日和周六
   expect(cronOne.find('.schedule-period.week .cron-select-wrapper .ant-select-selection__choice__content').text()).toBe('SunSat');
+});
+
+describe('cronValidate', () => {
+  it('week schedule', () => {
+    expect(cronValidate('0 0 2 ? * 1,2,3,4,5,6,7')).toBe(true);
+    expect(cronValidate('0 0 2 ? * 0,8')).toBe(false);
+    expect(cronValidate('0 0 2 ? * 0,1,2,3,4,5,6', false)).toBe(true);
+    expect(cronValidate('0 0 2 ? * 7,8', false)).toBe(false);
+    // cronValidate函数支持dayOfWeek字段是SUN,MON这种格式，但是OneCron组件并不支持这种格式，只支持像1,2这种数据格式
+    expect(cronValidate('0 0 2 ? * SUN,MON,TUE,WED,THU,FRI,SAT')).toBe(true);
+  });
 });

--- a/__tests__/OneCron.test.tsx
+++ b/__tests__/OneCron.test.tsx
@@ -32,3 +32,23 @@ it("renders the correct text when showRecentTime is true", () => {
     "Recently generated time"
   );
 });
+
+it("dayOfWeekOneBased prop is true by default", () => {
+  const cronExpression = '0 0 2 ? * 1,7';
+  const cronOne = Enzyme.render(
+    <OneCron cronExpression={cronExpression} />
+  );
+  expect(cronOne.find(".errorCronExp").length).toBe(0);
+  // 应该选中周日和周六
+  expect(cronOne.find('.schedule-period.week .cron-select-wrapper .ant-select-selection__choice__content').text()).toBe('SunSat');
+});
+
+it("dayOfWeekOneBased prop is false", () => {
+  const cronExpression = '0 0 2 ? * 0,6';
+  const cronOne = Enzyme.render(
+    <OneCron cronExpression={cronExpression} dayOfWeekOneBased={false} />
+  );
+  expect(cronOne.find(".errorCronExp").length).toBe(0);
+  // 应该选中周日和周六
+  expect(cronOne.find('.schedule-period.week .cron-select-wrapper .ant-select-selection__choice__content').text()).toBe('SunSat');
+});

--- a/src/cronExpValidator.ts
+++ b/src/cronExpValidator.ts
@@ -1,10 +1,12 @@
+import * as _ from "lodash";
+
 /**
  * Validates a cron expression.
  *
  * @param cronExpression The expression to validate
  * @return True is expression is valid
  */
-export function cronValidate(cronExpression: string) {
+export function cronValidate(cronExpression: string, dayOfWeekOneBased: boolean = true) {
   var cronParams = cronExpression ? cronExpression.split(" ") : "";
 
   if (cronParams.length < 6 || cronParams.length > 7) {
@@ -38,7 +40,7 @@ export function cronValidate(cronExpression: string) {
     }
 
     //Check day-of-week param
-    if (!checkDayOfWeekField(cronParams[5])) {
+    if (!checkDayOfWeekField(cronParams[5], dayOfWeekOneBased)) {
       return false;
     }
 
@@ -162,27 +164,27 @@ function checkMonthsField(monthsField: string) {
   return checkField(monthsField, 1, 31);
 }
 
-function checkDayOfWeekField(dayOfWeekField: string) {
-  dayOfWeekField.replace("SUN", "1");
-  dayOfWeekField.replace("MON", "2");
-  dayOfWeekField.replace("TUE", "3");
-  dayOfWeekField.replace("WED", "4");
-  dayOfWeekField.replace("THU", "5");
-  dayOfWeekField.replace("FRI", "6");
-  dayOfWeekField.replace("SAT", "7");
+const DAYS_OF_WEEK = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
+
+function checkDayOfWeekField(dayOfWeekField: string, dayOfWeekOneBased: boolean = true) {
+  _.forEach(DAYS_OF_WEEK, (text: string, index: number) => {
+    const value = dayOfWeekOneBased ? index + 1 : index;
+    dayOfWeekField.replace(text, `${value}`);
+  });
 
   if (dayOfWeekField == "?") {
     return true;
   }
 
+  const [min, max] = dayOfWeekOneBased ? [1, 7] : [0, 6];
   if (dayOfWeekField.indexOf("L") >= 0) {
-    return checkFieldWithLetter(dayOfWeekField, "L", 1, 7, -1, -1);
+    return checkFieldWithLetter(dayOfWeekField, "L", min, max, -1, -1);
   } else if (dayOfWeekField.indexOf("C") >= 0) {
-    return checkFieldWithLetter(dayOfWeekField, "C", 1, 7, -1, -1);
+    return checkFieldWithLetter(dayOfWeekField, "C", min, max, -1, -1);
   } else if (dayOfWeekField.indexOf("#") >= 0) {
-    return checkFieldWithLetter(dayOfWeekField, "#", 1, 7, 1, 5);
+    return checkFieldWithLetter(dayOfWeekField, "#", min, max, 1, 5);
   } else {
-    return checkField(dayOfWeekField, 1, 7);
+    return checkField(dayOfWeekField, min, max);
   }
 }
 

--- a/src/cronExpValidator.ts
+++ b/src/cronExpValidator.ts
@@ -169,7 +169,7 @@ const DAYS_OF_WEEK = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
 function checkDayOfWeekField(dayOfWeekField: string, dayOfWeekOneBased: boolean = true) {
   _.forEach(DAYS_OF_WEEK, (text: string, index: number) => {
     const value = dayOfWeekOneBased ? index + 1 : index;
-    dayOfWeekField.replace(text, `${value}`);
+    dayOfWeekField = dayOfWeekField.replace(text, `${value}`);
   });
 
   if (dayOfWeekField == "?") {

--- a/src/cronUtils.ts
+++ b/src/cronUtils.ts
@@ -455,13 +455,13 @@ class HourCron extends Cron {
           // 结束时间减去开始时间/间隔，然后slice(0,times)
           const count = Math.ceil(minDiff / (+stepHour * 60));
           predictedTimes = typeof count === 'number' && getArr(count)
-              .slice(0, times)
-              .map(
-                (item, index) =>
-                  `${Moment(beginTime)
-                    .add(+stepHour * index, "hours")
-                    .format(format)}`
-              );
+            .slice(0, times)
+            .map(
+              (item, index) =>
+                `${Moment(beginTime)
+                  .add(+stepHour * index, "hours")
+                  .format(format)}`
+            );
         }
       }
     } else {

--- a/src/cronUtils.ts
+++ b/src/cronUtils.ts
@@ -47,13 +47,13 @@ export const getDayItems = (lang: LangEnum) => {
   });
 };
 
-export const getWeekItems = (lang: LangEnum) => {
+export const getWeekItems = (lang: LangEnum, dayOfWeekOneBased: boolean = true) => {
   const I18N = getI18N(lang);
   const weekItemsList = I18N["weekItemsList"];
   return weekItemsList.map((day, dayIndex) => {
     return {
       text: day,
-      value: dayIndex + 1 + ""
+      value: dayIndex + (dayOfWeekOneBased ? 1 : 0) + "",
     };
   });
 };
@@ -104,11 +104,11 @@ export class Cron {
     });
   }
 
-  static getCronFromPeriodType(periodType: PeriodType) {
+  static getCronFromPeriodType(periodType: PeriodType, dayOfWeekOneBased: boolean = true) {
     if (periodType === PeriodType.day) {
       return new DayCron({});
     } else if (periodType === PeriodType.week) {
-      return new WeekCron({});
+      return new WeekCron({ dayOfWeekOneBased });
     } else if (periodType === PeriodType.month) {
       return new MonthCron({});
     } else if (periodType === PeriodType.hour) {
@@ -120,12 +120,12 @@ export class Cron {
     }
   }
 
-  static getCronFromExp(cronExp: string) {
+  static getCronFromExp(cronExp: string, dayOfWeekOneBased: boolean = true) {
     if (!cronExp) {
       return new DayCron({});
     }
     // 验证cronExp正确性
-    if (!cronValidate(cronExp)) {
+    if (!cronValidate(cronExp, dayOfWeekOneBased)) {
       return new DayCron({});
     }
 
@@ -145,7 +145,8 @@ export class Cron {
     } else if (day === "?") {
       return new WeekCron({
         time: Moment(`${hour}:${minute}`, "HH:mm"),
-        weeks: week.split(",")
+        weeks: week.split(","),
+        dayOfWeekOneBased
       });
     } else if (day !== "*" && isStrNum(hour)) {
       // 每月多少号
@@ -322,6 +323,8 @@ class WeekCron extends Cron {
 
   weeks = [] as string[];
   time = Moment("00:00", "HH:mm");
+  // day of week是否从1开始。如果为true时，周日至周六对应1~7；否则从0开始，周日至周六对应0~6
+  dayOfWeekOneBased = true;
 
   format() {
     const { weeks, time } = this;
@@ -335,7 +338,7 @@ class WeekCron extends Cron {
   }
 
   generatePredictedTime(times = 5, format = DEFAULT_FORMAT): string[] {
-    const { weeks, time } = this;
+    const { weeks, time, dayOfWeekOneBased } = this;
     const curretWeek = +Moment().format("E") === 7 ? 0 : +Moment().format("E");
     // 找到若插入sortedDays中的索引
     const sortedIndex = _.sortedIndex(weeks, +curretWeek);
@@ -344,9 +347,21 @@ class WeekCron extends Cron {
       ..._.sortedUniq(weeks.slice(0, sortedIndex))
     ]
       .slice(0, times)
-      .map((child, index) => {
-        // child为1时表示为周日
-        const diff = Number(child) === 1 ? 7 - curretWeek : Number(child) - curretWeek - 1;
+      .map(dayStr => {
+        const day = Number(dayStr);
+        let diff: number;
+
+        if (dayOfWeekOneBased) {
+          // day为1时表示为周日
+          diff = day === 1 ? 7 - curretWeek : day - curretWeek - 1;
+        } else {
+          // day为0时表示周日
+          diff = day - curretWeek;
+          if (diff < 0) {
+            diff = diff + 7;
+          }
+        }
+
         if (diff === 0) {
           const isBefore = Moment().isBefore(time);
           return Moment(time)
@@ -440,13 +455,13 @@ class HourCron extends Cron {
           // 结束时间减去开始时间/间隔，然后slice(0,times)
           const count = Math.ceil(minDiff / (+stepHour * 60));
           predictedTimes = typeof count === 'number' && getArr(count)
-            .slice(0, times)
-            .map(
-              (item, index) =>
-                `${Moment(beginTime)
-                  .add(+stepHour * index, "hours")
-                  .format(format)}`
-            );
+              .slice(0, times)
+              .map(
+                (item, index) =>
+                  `${Moment(beginTime)
+                    .add(+stepHour * index, "hours")
+                    .format(format)}`
+              );
         }
       }
     } else {
@@ -494,7 +509,7 @@ class MinuteCron extends Cron {
           );
       }
     }
-    
+
     return predictedTimes;
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -57,7 +57,9 @@ export class OneCronProps {
   /** 是否支持多选 */
   multiple? = true;
   /** 错误信息 */
-  errorMessage? = ''
+  errorMessage? = '';
+  /** day of week是否从1开始。如果为true时，周日至周六对应1~7；否则从0开始，周日至周六对应0~6 */
+  dayOfWeekOneBased = true;
 }
 interface OneCronState {
   cron: AllCron;
@@ -75,7 +77,7 @@ export default class OneCron extends React.Component<
 
   constructor(props: OneCronProps) {
     super(props);
-    const cron = Cron.getCronFromExp(props.cronExpression);
+    const cron = Cron.getCronFromExp(props.cronExpression, props.dayOfWeekOneBased);
 
     this.state = {
       cron,
@@ -90,7 +92,7 @@ export default class OneCron extends React.Component<
   componentWillReceiveProps(nextProps: OneCronProps) {
     if (nextProps.cronExpression !== this.props.cronExpression) {
       if (this.state.isEmpty) {
-        const newCron = Cron.getCronFromExp(nextProps.cronExpression);
+        const newCron = Cron.getCronFromExp(nextProps.cronExpression, nextProps.dayOfWeekOneBased);
         const cronType =  newCron.periodType;
         this.setState({
           cron: newCron,
@@ -103,7 +105,7 @@ export default class OneCron extends React.Component<
   }
 
   handleChangePeriodType(periodType: PeriodType) {
-    const newCron = Cron.getCronFromPeriodType(periodType);
+    const newCron = Cron.getCronFromPeriodType(periodType, this.props.dayOfWeekOneBased);
     this.setState(
       {
         cron: newCron,
@@ -197,7 +199,8 @@ export default class OneCron extends React.Component<
       disabled,
       beginTime = 0,
       endTime = 24,
-      multiple
+      multiple,
+      dayOfWeekOneBased,
     } = this.props;
     const disabledHours = () => [
       ...getArr(beginTime, 0),
@@ -286,7 +289,7 @@ export default class OneCron extends React.Component<
                 }}
                 value={cron.weeks.filter(item => item !== '*')}
               >
-                {getOptions(getWeekItems(lang))}
+                {getOptions(getWeekItems(lang, dayOfWeekOneBased))}
               </Select>
               {this.state.isError && this.props.errorMessage && <div className="cron-select-errorMessage">{this.props.errorMessage}</div>}
             </span> 
@@ -493,12 +496,13 @@ export default class OneCron extends React.Component<
       showCheckbox,
       disabled,
       showRecentTime,
-      options
+      options,
+      dayOfWeekOneBased,
     } = this.props;
     const I18N = getI18N(lang);
     const { cron } = this.state;
     const typeCx = cron.periodType;
-    const isValidate = cronValidate(cronExpression);
+    const isValidate = cronValidate(cronExpression, dayOfWeekOneBased);
     return (
       <span className={`schedule-period ${typeCx}`}>
         <Select


### PR DESCRIPTION
### Background

目前cron表达式中的day of week值是1\~7，即周日\~周六分别对应1\~7，例如'0 0 2 ? * 1,7'。但是在某些场景下，day of week值是0\~6，即周日-周六分别对应0\~6，例如'0 0 2 ? * 0,6'.

### Solution

OneCron组件里增加了`dayOfWeekOneBased` prop（表示是day of week是否从1开始），来区分这这两种使用场景。如果`dayOfWeekOneBased`为true，周日至周六对应1\~7；否则从0开始，周日至周六对应0\~6。默认是true，即目前使用的1\~7。
