### PR TITLE
feat: 支持关闭cron表达式的严格校验逻辑，默认是打开

### DIFF
--- a/__tests__/OneCron.test.tsx
+++ b/__tests__/OneCron.test.tsx
@@ -61,5 +61,9 @@ describe('cronValidate', () => {
     expect(cronValidate('0 0 2 ? * 7,8', false)).toBe(false);
     // cronValidate函数支持dayOfWeek字段是SUN,MON这种格式，但是OneCron组件并不支持这种格式，只支持像1,2这种数据格式
     expect(cronValidate('0 0 2 ? * SUN,MON,TUE,WED,THU,FRI,SAT')).toBe(true);
+    // 测试strictValidate默认为true
+    expect(cronValidate('0 0 2 ? * 6,0', false)).toBe(false);
+    // 测试strictValidate为false
+    expect(cronValidate('0 0 2 ? * 6,0', false, false)).toBe(true);
   });
 });

--- a/src/cronUtils.ts
+++ b/src/cronUtils.ts
@@ -120,12 +120,12 @@ export class Cron {
     }
   }
 
-  static getCronFromExp(cronExp: string, dayOfWeekOneBased: boolean = true) {
+  static getCronFromExp(cronExp: string, dayOfWeekOneBased = true, strictValidate = true) {
     if (!cronExp) {
       return new DayCron({});
     }
     // 验证cronExp正确性
-    if (!cronValidate(cronExp, dayOfWeekOneBased)) {
+    if (!cronValidate(cronExp, dayOfWeekOneBased, strictValidate)) {
       return new DayCron({});
     }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -60,6 +60,11 @@ export class OneCronProps {
   errorMessage? = '';
   /** day of week是否从1开始。如果为true时，周日至周六对应1~7；否则从0开始，周日至周六对应0~6 */
   dayOfWeekOneBased = true;
+  /**
+   * 是否严格校验cron表达式。如果为true，cron表达式的day of week字段必须是严格递增的, 
+   * 例如day of week是'5,6'，则是合法的。但如果是'6,5'，则校验不通过
+   */
+  strictValidate = true;
 }
 interface OneCronState {
   cron: AllCron;
@@ -76,8 +81,8 @@ export default class OneCron extends React.Component<
   static defaultProps = new OneCronProps();
 
   constructor(props: OneCronProps) {
-    super(props);
-    const cron = Cron.getCronFromExp(props.cronExpression, props.dayOfWeekOneBased);
+    super(props); 
+    const cron = Cron.getCronFromExp(props.cronExpression, props.dayOfWeekOneBased, props.strictValidate);
 
     this.state = {
       cron,
@@ -92,7 +97,7 @@ export default class OneCron extends React.Component<
   componentWillReceiveProps(nextProps: OneCronProps) {
     if (nextProps.cronExpression !== this.props.cronExpression) {
       if (this.state.isEmpty) {
-        const newCron = Cron.getCronFromExp(nextProps.cronExpression, nextProps.dayOfWeekOneBased);
+        const newCron = Cron.getCronFromExp(nextProps.cronExpression, nextProps.dayOfWeekOneBased, nextProps.strictValidate);
         const cronType =  newCron.periodType;
         this.setState({
           cron: newCron,
@@ -498,11 +503,12 @@ export default class OneCron extends React.Component<
       showRecentTime,
       options,
       dayOfWeekOneBased,
+      strictValidate,
     } = this.props;
     const I18N = getI18N(lang);
     const { cron } = this.state;
     const typeCx = cron.periodType;
-    const isValidate = cronValidate(cronExpression, dayOfWeekOneBased);
+    const isValidate = cronValidate(cronExpression, dayOfWeekOneBased, strictValidate);
     return (
       <span className={`schedule-period ${typeCx}`}>
         <Select


### PR DESCRIPTION
### Background

目前cron表达式中的day of week字段要求是严格递增的，例如'0 0 2 ? * 1,7'中dayOfWeek字段'1,7'必须是递增的，如果dayOfWeek是'7,1'，则校验不通过。 但是在某些场景下，dayOfWeek可能不是严格递增的。

### Solution

OneCron组件增加strictValidate prop，控制是否严格校验dayOfWeek字段，如果为true，表示严格校验，否则关闭严格校验。默认为true，保证向后兼容。
