### PR TITLE
fix: 调度周期选择周，清空时间框后，最近的生成时间显示为invalid date

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -319,6 +319,7 @@ export default class OneCron extends React.Component<
 
         return (
           <TimePicker
+            allowClear={false}
             disabledTime={() => ({ disabledHours })}
             format="HH:mm"
             {...getCommonProps(cron, "time")}
@@ -359,6 +360,7 @@ export default class OneCron extends React.Component<
             </span>
 
             <TimePicker
+              allowClear={false}
               disabledTime={() => ({ disabledHours })}
               format="HH:mm"
               {...getCommonProps(cron, "time")}
@@ -399,6 +401,7 @@ export default class OneCron extends React.Component<
               )}
             </span>
             <TimePicker
+              allowClear={false}
               disabledTime={() => ({ disabledHours })}
               format="HH:mm"
               {...getCommonProps(cron, "time")}
@@ -437,6 +440,7 @@ export default class OneCron extends React.Component<
           <span>
             <span className="form-item">
               <RangePicker
+                allowClear={false}
                 disabled={disabled}
                 format="HH:mm"
                 disabledTime={(date: Moment.Moment, type: RangeType) => ({
@@ -505,6 +509,7 @@ export default class OneCron extends React.Component<
               <span>
                 <span className="form-item">
                   <RangePicker
+                    allowClear={false}
                     disabled={disabled}
                     format="HH:mm"
                     disabledTime={(date: Moment.Moment, type: RangeType) =>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/42641779/207247890-be8390b6-8f5e-4ded-825a-68651c2379fb.png)


![image](https://user-images.githubusercontent.com/42641779/207247031-38d44645-0c63-4a87-9e61-2cb9861dedbb.png)
